### PR TITLE
增加getPresetProperties方法，方便提取预制属性。

### DIFF
--- a/common-api.js
+++ b/common-api.js
@@ -98,6 +98,9 @@ let sa = {
 	getAnonymousID: () => {
 		console.log('common-api,当前平台不支持此方法 getAnonymousID');
 	},
+	getPresetProperties: () => {
+		console.log('common-api,当前平台不支持此方法 getPresetProperties');
+	},
 
 	register: (para) => {
 		console.log('common-api,当前平台不支持此方法 register');


### PR DESCRIPTION
getPresetProperties方法在微信，支付宝，百度，web的sdk里都支持，通用性很好。
这里加上之后，在uniapp拉起webview前，可以用来提取$latest_sa_utm等参数传递给webview，实现来源，场景等打通。